### PR TITLE
Add a timeout to the data collection

### DIFF
--- a/src/mx_bluesky/I24/serial/extruder/i24ssx_Extruder_Collect_py3v2.py
+++ b/src/mx_bluesky/I24/serial/extruder/i24ssx_Extruder_Collect_py3v2.py
@@ -343,48 +343,46 @@ def run_extruderi24(args=None):
 
     aborted = False
     timeout_time = time.time() + int(num_imgs) * float(exp_time) + 10
-    while True:
-        if int(caget(pv.ioc12_gp8)) == 0:  # ioc12_gp8 is the ABORT button
-            caput(pv.zebra1_pc_arm, 1)
-            sleep(gate_start)
-            i = 0
-            text_list = ["|", "/", "-", "\\"]
-            while True:
-                line_of_text = "\r\t\t\t Waiting   " + 30 * ("%s" % text_list[i % 4])
-                flush_print(line_of_text)
-                sleep(0.5)
-                i += 1
-                if int(caget(pv.ioc12_gp8)) != 0:
-                    aborted = True
-                    logger.warning("Data Collection Aborted")
-                    if det_type == "pilatus":
-                        caput(pv.pilat_acquire, 0)
-                    elif det_type == "eiger":
-                        caput(pv.eiger_acquire, 0)
-                    sleep(1.0)
-                    break
-                elif int(caget(pv.zebra1_pc_arm_out)) != 1:
-                    # As soon as the zebra1_pc_arm_out is not 1 anymore, exit.
-                    # Epics checks the geobrick and updates this PV once the collection is done.
-                    logger.info("----> Zebra disarmed  <----")
-                    break
-                elif time.time() >= timeout_time:
-                    logger.warning(
-                        """
-                        Something went wrong and data collection timed out. Aborting.
+
+    if int(caget(pv.ioc12_gp8)) == 0:  # ioc12_gp8 is the ABORT button
+        caput(pv.zebra1_pc_arm, 1)
+        sleep(gate_start)
+        i = 0
+        text_list = ["|", "/", "-", "\\"]
+        while True:
+            line_of_text = "\r\t\t\t Waiting   " + 30 * ("%s" % text_list[i % 4])
+            flush_print(line_of_text)
+            sleep(0.5)
+            i += 1
+            if int(caget(pv.ioc12_gp8)) != 0:
+                aborted = True
+                logger.warning("Data Collection Aborted")
+                if det_type == "pilatus":
+                    caput(pv.pilat_acquire, 0)
+                elif det_type == "eiger":
+                    caput(pv.eiger_acquire, 0)
+                sleep(1.0)
+                break
+            elif int(caget(pv.zebra1_pc_arm_out)) != 1:
+                # As soon as the zebra1_pc_arm_out is not 1 anymore, exit.
+                # Epics checks the geobrick and updates this PV once the collection is done.
+                logger.info("----> Zebra disarmed  <----")
+                break
+            elif time.time() >= timeout_time:
+                logger.warning(
                     """
-                    )
-                    if det_type == "pilatus":
-                        caput(pv.pilat_acquire, 0)
-                    elif det_type == "eiger":
-                        caput(pv.eiger_acquire, 0)
-                    sleep(1.0)
-                    break
-        else:
-            aborted = True
-            logger.warning("Data Collection ended due to GP 8 not equalling 0")
-            break
-        break
+                    Something went wrong and data collection timed out. Aborting.
+                """
+                )
+                if det_type == "pilatus":
+                    caput(pv.pilat_acquire, 0)
+                elif det_type == "eiger":
+                    caput(pv.eiger_acquire, 0)
+                sleep(1.0)
+                break
+    else:
+        aborted = True
+        logger.warning("Data Collection ended due to GP 8 not equalling 0")
 
     caput(pv.ioc12_gp8, 1)
     logger.info("Fast shutter closing")

--- a/src/mx_bluesky/I24/serial/extruder/i24ssx_Extruder_Collect_py3v2.py
+++ b/src/mx_bluesky/I24/serial/extruder/i24ssx_Extruder_Collect_py3v2.py
@@ -342,7 +342,7 @@ def run_extruderi24(args=None):
         call_nexgen(None, start_time, param_file_tuple, "extruder")
 
     aborted = False
-    timeout = time.time() + int(num_imgs) * float(exp_time) + 1
+    timeout_time = time.time() + int(num_imgs) * float(exp_time) + 10
     while True:
         if int(caget(pv.ioc12_gp8)) == 0:  # ioc12_gp8 is the ABORT button
             caput(pv.zebra1_pc_arm, 1)
@@ -364,9 +364,11 @@ def run_extruderi24(args=None):
                     sleep(1.0)
                     break
                 elif int(caget(pv.zebra1_pc_arm_out)) != 1:
+                    # As soon as the zebra1_pc_arm_out is not 1 anymore, exit.
+                    # Epics checks the geobrick and updates this PV once the collection is done.
                     logger.info("----> Zebra disarmed  <----")
                     break
-                elif time.time() >= timeout:
+                elif time.time() >= timeout_time:
                     logger.warning(
                         """
                         Something went wrong and data collection timed out. Aborting.

--- a/src/mx_bluesky/I24/serial/extruder/i24ssx_Extruder_Collect_py3v2.py
+++ b/src/mx_bluesky/I24/serial/extruder/i24ssx_Extruder_Collect_py3v2.py
@@ -342,7 +342,7 @@ def run_extruderi24(args=None):
         call_nexgen(None, start_time, param_file_tuple, "extruder")
 
     aborted = False
-    timeout = time.time() + num_imgs * exp_time + 1
+    timeout = time.time() + int(num_imgs) * float(exp_time) + 1
     while True:
         if int(caget(pv.ioc12_gp8)) == 0:  # ioc12_gp8 is the ABORT button
             caput(pv.zebra1_pc_arm, 1)

--- a/src/mx_bluesky/I24/serial/extruder/i24ssx_Extruder_Collect_py3v2.py
+++ b/src/mx_bluesky/I24/serial/extruder/i24ssx_Extruder_Collect_py3v2.py
@@ -342,6 +342,7 @@ def run_extruderi24(args=None):
         call_nexgen(None, start_time, param_file_tuple, "extruder")
 
     aborted = False
+    timeout = time.time() + num_imgs * exp_time + 1
     while True:
         if int(caget(pv.ioc12_gp8)) == 0:  # ioc12_gp8 is the ABORT button
             caput(pv.zebra1_pc_arm, 1)
@@ -364,6 +365,18 @@ def run_extruderi24(args=None):
                     break
                 elif int(caget(pv.zebra1_pc_arm_out)) != 1:
                     logger.info("----> Zebra disarmed  <----")
+                    break
+                elif time.time() >= timeout:
+                    logger.warning(
+                        """
+                        Something went wrong and data collection timed out. Aborting.
+                    """
+                    )
+                    if det_type == "pilatus":
+                        caput(pv.pilat_acquire, 0)
+                    elif det_type == "eiger":
+                        caput(pv.eiger_acquire, 0)
+                    sleep(1.0)
                     break
         else:
             aborted = True

--- a/src/mx_bluesky/I24/serial/fixed_target/i24ssx_Chip_Collect_py3v1.py
+++ b/src/mx_bluesky/I24/serial/fixed_target/i24ssx_Chip_Collect_py3v1.py
@@ -610,7 +610,7 @@ def main():
     logger.info("Data Collection running")
 
     aborted = False
-    timeout = time.time() + datasetsizei24() * exptime + 10
+    timeout = time.time() + datasetsizei24() * float(exptime) + 10
     while True:
         # me14e_gp9 is the ABORT button
         if int(caget(pv.me14e_gp9)) == 0:

--- a/src/mx_bluesky/I24/serial/fixed_target/i24ssx_Chip_Collect_py3v1.py
+++ b/src/mx_bluesky/I24/serial/fixed_target/i24ssx_Chip_Collect_py3v1.py
@@ -611,46 +611,44 @@ def main():
 
     aborted = False
     timeout_time = time.time() + datasetsizei24() * float(exptime) + 60
-    while True:
-        # me14e_gp9 is the ABORT button
-        if int(caget(pv.me14e_gp9)) == 0:
-            i = 0
-            text_list = ["|", "/", "-", "\\"]
-            while True:
-                line_of_text = "\r\t\t\t Waiting   " + 30 * ("%s" % text_list[i % 4])
-                flush_print(line_of_text)
-                sleep(0.5)
-                i += 1
-                if int(caget(pv.me14e_gp9)) != 0:
-                    aborted = True
-                    logger.warning("Data Collection Aborted")
-                    caput(pv.me14e_pmac_str, "A")
-                    sleep(1.0)
-                    caput(pv.me14e_pmac_str, "P2401=0")
-                    break
-                elif int(caget(pv.me14e_scanstatus)) == 0:
-                    # As soon as me14e_scanstatus is set to 0, exit.
-                    # Epics checks the geobrick and updates this PV every s or so.
-                    # Once the collection is done, it will be set to 0.
-                    print(caget(pv.me14e_scanstatus))
-                    logger.warning("Data Collection Finished")
-                    break
-                elif time.time() >= timeout_time:
-                    aborted = True
-                    logger.warning(
-                        """
-                        Something went wrong and data collection timed out. Aborting.
-                        """
-                    )
-                    caput(pv.me14e_pmac_str, "A")
-                    sleep(1.0)
-                    caput(pv.me14e_pmac_str, "P2401=0")
-                    break
-        else:
-            aborted = True
-            logger.info("Data Collection ended due to GP 9 not equalling 0")
-            break
-        break
+
+    # me14e_gp9 is the ABORT button
+    if int(caget(pv.me14e_gp9)) == 0:
+        i = 0
+        text_list = ["|", "/", "-", "\\"]
+        while True:
+            line_of_text = "\r\t\t\t Waiting   " + 30 * ("%s" % text_list[i % 4])
+            flush_print(line_of_text)
+            sleep(0.5)
+            i += 1
+            if int(caget(pv.me14e_gp9)) != 0:
+                aborted = True
+                logger.warning("Data Collection Aborted")
+                caput(pv.me14e_pmac_str, "A")
+                sleep(1.0)
+                caput(pv.me14e_pmac_str, "P2401=0")
+                break
+            elif int(caget(pv.me14e_scanstatus)) == 0:
+                # As soon as me14e_scanstatus is set to 0, exit.
+                # Epics checks the geobrick and updates this PV every s or so.
+                # Once the collection is done, it will be set to 0.
+                print(caget(pv.me14e_scanstatus))
+                logger.warning("Data Collection Finished")
+                break
+            elif time.time() >= timeout_time:
+                aborted = True
+                logger.warning(
+                    """
+                    Something went wrong and data collection timed out. Aborting.
+                    """
+                )
+                caput(pv.me14e_pmac_str, "A")
+                sleep(1.0)
+                caput(pv.me14e_pmac_str, "P2401=0")
+                break
+    else:
+        aborted = True
+        logger.info("Data Collection ended due to GP 9 not equalling 0")
 
     logger.debug("Closing fast shutter")
     caput(pv.zebra1_soft_in_b1, "No")  # Close the fast shutter

--- a/src/mx_bluesky/I24/serial/fixed_target/i24ssx_Chip_Collect_py3v1.py
+++ b/src/mx_bluesky/I24/serial/fixed_target/i24ssx_Chip_Collect_py3v1.py
@@ -610,7 +610,7 @@ def main():
     logger.info("Data Collection running")
 
     aborted = False
-    timeout = time.time() + datasetsizei24() * float(exptime) + 10
+    timeout_time = time.time() + datasetsizei24() * float(exptime) + 60
     while True:
         # me14e_gp9 is the ABORT button
         if int(caget(pv.me14e_gp9)) == 0:
@@ -629,10 +629,13 @@ def main():
                     caput(pv.me14e_pmac_str, "P2401=0")
                     break
                 elif int(caget(pv.me14e_scanstatus)) == 0:
+                    # As soon as me14e_scanstatus is set to 0, exit.
+                    # Epics checks the geobrick and updates this PV every s or so.
+                    # Once the collection is done, it will be set to 0.
                     print(caget(pv.me14e_scanstatus))
                     logger.warning("Data Collection Finished")
                     break
-                elif time.time() >= timeout:
+                elif time.time() >= timeout_time:
                     aborted = True
                     logger.warning(
                         """

--- a/src/mx_bluesky/I24/serial/fixed_target/i24ssx_Chip_Collect_py3v1.py
+++ b/src/mx_bluesky/I24/serial/fixed_target/i24ssx_Chip_Collect_py3v1.py
@@ -610,6 +610,7 @@ def main():
     logger.info("Data Collection running")
 
     aborted = False
+    timeout = time.time() + datasetsizei24() * exptime + 10
     while True:
         # me14e_gp9 is the ABORT button
         if int(caget(pv.me14e_gp9)) == 0:
@@ -630,6 +631,17 @@ def main():
                 elif int(caget(pv.me14e_scanstatus)) == 0:
                     print(caget(pv.me14e_scanstatus))
                     logger.warning("Data Collection Finished")
+                    break
+                elif time.time() >= timeout:
+                    aborted = True
+                    logger.warning(
+                        """
+                        Something went wrong and data collection timed out. Aborting.
+                        """
+                    )
+                    caput(pv.me14e_pmac_str, "A")
+                    sleep(1.0)
+                    caput(pv.me14e_pmac_str, "P2401=0")
                     break
         else:
             aborted = True


### PR DESCRIPTION
Temporarily add a timeout to the data collection in case something goes wrong and it gets stuck. During the last testing there were a few issues that caused the data collection to fail, but the script was not getting out of the while loop and just kept going because conditions on the PVs were not met. It also could not be easily killed from the terminal.
Needs a better solution for the future but this should allow for a slightly safer testing of the deployment. 

Timeout is calculated from the number of images to be collected and the exposure time plus a constant in seconds. Probably overdoing it with the chip, but better be safe since I'm not considering the pump_repeat in it. 