### PR TITLE
Use ruff as a linter

### DIFF
--- a/.github/pages/make_switcher.py
+++ b/.github/pages/make_switcher.py
@@ -59,7 +59,7 @@ def get_versions(ref: str, add: Optional[str], remove: Optional[str]) -> List[st
 def write_json(path: Path, repository: str, versions: str):
     org, repo_name = repository.split("/")
     struct = [
-        dict(version=version, url=f"https://{org}.github.io/{repo_name}/{version}/")
+        {"version": version, "url": f"https://{org}.github.io/{repo_name}/{version}/"}
         for version in versions
     ]
     text = json.dumps(struct, indent=2)

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           requirements_file: requirements-dev-3.x.txt
           install_options: -e .[dev]
+          python_version: "3.11"
 
       - name: Lint
         run: tox -e pre-commit,mypy

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           requirements_file: requirements-dev-3.x.txt
           install_options: -e .[dev]
+          python_version: "3.11"
 
       - name: Build docs
         run: tox -e docs

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           requirements_file: requirements-dev-3.x.txt
           install_options: -e .[dev]
+          python_version: "3.11"
 
       - name: Check links
         run: tox -e docs build -- -b linkcheck

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,9 @@ venv*
 # further build artifacts
 lockfiles/
 
+# ruff cache
+.ruff_cache/
+
 # EDM screens
 edm/
 edm_serial/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,26 +15,15 @@ repos:
         files: \.pyi?
         types: [file]
 
-  # Sort imports
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+  # Linter
+  - repo: local
     hooks:
-      - id: isort
-        name: isort (python)
-        args:
-          [
-            "--profile=black",
-            '--add_imports="from __future__ import annotations',
-          ]
-
-  # Linting
-  - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          ["flake8-comprehensions==3.8.0", "Flake8-pyproject"]
-        args: ["--max-line-length=88", "--ignore=E203,F811,F722,E501,W503,C408"]
+      - id: ruff
+        name: Run ruff
+        stages: [commit]
+        language: system
+        entry: ruff
+        types: [python]
 
   # Type checking
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
 
   # Type checking
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.931
+    rev: v1.4.1
     hooks:
       - id: mypy
         files: 'src/.*\.py$'

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
         "ms-python.python",
         "tamasfe.even-better-toml",
         "redhat.vscode-yaml",
-        "ryanluker.vscode-coverage-gutters"
+        "ryanluker.vscode-coverage-gutters",
+        "charliermarsh.Ruff"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "python.linting.pylintEnabled": false,
-    "python.linting.flake8Enabled": true,
+    "python.linting.flake8Enabled": false,
     "python.linting.mypyEnabled": true,
     "python.linting.enabled": true,
     "python.testing.pytestArgs": [],
@@ -9,7 +9,13 @@
     "python.formatting.provider": "black",
     "python.languageServer": "Pylance",
     "editor.formatOnSave": true,
-    "editor.codeActionsOnSave": {
-        "source.organizeImports": true
-    }
+    "[python]": {
+        "editor.rulers": [
+            88
+        ],
+        "editor.codeActionsOnSave": {
+            "source.fixAll.ruff": false,
+            "source.organizeImports.ruff": true
+        }
+    },
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,10 +98,10 @@ pygments_style = "sphinx"
 
 # This means you can link things like `str` and `asyncio` to the relevant
 # docs in the python documentation.
-intersphinx_mapping = dict(python=("https://docs.python.org/3/", None))
+intersphinx_mapping = {"python": ("https://docs.python.org/3/", None)}
 
 # A dictionary of graphviz graph attributes for inheritance diagrams.
-inheritance_graph_attrs = dict(rankdir="TB")
+inheritance_graph_attrs = {"rankdir": "TB"}
 
 # Common links that should be available on every page
 rst_epilog = """
@@ -142,40 +142,40 @@ if not check_switcher:
     )
 
 # Theme options for pydata_sphinx_theme
-html_theme_options = dict(
-    logo=dict(
-        text=project,
-    ),
-    use_edit_page_button=True,
-    github_url=f"https://github.com/{github_user}/{github_repo}",
-    icon_links=[
-        dict(
-            name="PyPI",
-            url=f"https://pypi.org/project/{project}",
-            icon="fas fa-cube",
-        )
+html_theme_options = {
+    "logo": {
+        "text": project,
+    },
+    "use_edit_page_button": True,
+    "github_url": f"https://github.com/{github_user}/{github_repo}",
+    "icon_links": [
+        {
+            "name": "PyPI",
+            "url": f"https://pypi.org/project/{project}",
+            "icon": "fas fa-cube",
+        }
     ],
-    switcher=dict(
-        json_url=switcher_json,
-        version_match=version,
-    ),
-    check_switcher=check_switcher,
-    navbar_end=["theme-switcher", "icon-links", "version-switcher"],
-    external_links=[
-        dict(
-            name="Release Notes",
-            url=f"https://github.com/{github_user}/{github_repo}/releases",
-        )
+    "switcher": {
+        "json_url": switcher_json,
+        "version_match": version,
+    },
+    "check_switcher": check_switcher,
+    "navbar_end": ["theme-switcher", "icon-links", "version-switcher"],
+    "external_links": [
+        {
+            "name": "Release Notes",
+            "url": f"https://github.com/{github_user}/{github_repo}/releases",
+        }
     ],
-)
+}
 
 # A dictionary of values to pass into the template engine’s context for all pages
-html_context = dict(
-    github_user=github_user,
-    github_repo=project,
-    github_version=version,
-    doc_path="docs",
-)
+html_context = {
+    "github_user": github_user,
+    "github_repo": project,
+    "github_version": version,
+    "doc_path": "docs",
+}
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
 html_show_sphinx = False

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,8 +107,6 @@ inheritance_graph_attrs = {"rankdir": "TB"}
 rst_epilog = """
 .. _Diamond Light Source: http://www.diamond.ac.uk
 .. _black: https://github.com/psf/black
-.. _flake8: https://flake8.pycqa.org/en/latest/
-.. _isort: https://github.com/PyCQA/isort
 .. _mypy: http://mypy-lang.org/
 .. _pre-commit: https://pre-commit.com/
 """

--- a/docs/developer/how-to/lint.rst
+++ b/docs/developer/how-to/lint.rst
@@ -1,7 +1,7 @@
 Run linting using pre-commit
 ============================
 
-Code linting is handled by black_, flake8_ and isort_ run under pre-commit_.
+Code linting is handled by black_, ruff run under pre-commit_.
 
 Running pre-commit
 ------------------
@@ -23,11 +23,7 @@ repository::
 
     $ black .
 
-Likewise with isort::
-
-    $ isort .
-
-If you get any flake8 issues you will have to fix those manually.
+If you get any ruff issues you will have to fix those manually.
 
 VSCode support
 --------------

--- a/docs/developer/reference/standards.rst
+++ b/docs/developer/reference/standards.rst
@@ -10,8 +10,7 @@ Code Standards
 The code in this repository conforms to standards set by the following tools:
 
 - black_ for code formatting
-- flake8_ for style checks
-- isort_ for import ordering
+- ruff for linting
 - mypy_ for static type checking
 
 .. seealso::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "matplotlib",
     "requests",
     "opencv-python",
-    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@main",
+    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@b980f9b",
 ]
 dynamic = ["version"]
 license.file = "LICENSE"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,12 +31,11 @@ requires-python = ">=3.9"
 dev = [
     "black",
     "mypy",
-    "flake8-isort",
-    "Flake8-pyproject",
     "pipdeptree",
     "pre-commit",
     "pydata-sphinx-theme>=0.12",
     "pytest-cov",
+    "ruff",
     "sphinx-autobuild",
     "sphinx-copybutton",
     "sphinx-design",
@@ -66,19 +65,20 @@ write_to = "src/mx_bluesky/_version.py"
 [tool.mypy]
 ignore_missing_imports = true # Ignore missing stubs in imported modules
 
-[tool.isort]
-float_to_top = true
-profile = "black"
-
-[tool.flake8]
+[tool.ruff]
+src = ["src", "tests"]
+line-length = 88
 extend-ignore = [
-    "E203", # See https://github.com/PyCQA/pycodestyle/issues/373
+    "E501", # Line too long
     "F811", # support typing.overload decorator
-    "F722", # allow Annotated[typ, some_func("some string")]
 ]
-max-line-length = 88 # Respect black's line length (default 88),
-exclude = [".tox", "venv"]
-
+select = [
+    "C4",   # flake8-comprehensions - https://beta.ruff.rs/docs/rules/#flake8-comprehensions-c4
+    "E",    # pycodestyle errors - https://beta.ruff.rs/docs/rules/#error-e
+    "F",    # pyflakes rules - https://beta.ruff.rs/docs/rules/#pyflakes-f
+    "W",    # pycodestyle warnings - https://beta.ruff.rs/docs/rules/#warning-w
+    "I001", # isort
+]
 
 [tool.pytest.ini_options]
 # Run pytest with all our checkers, and don't spam us with massive tracebacks on error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "matplotlib",
     "requests",
     "opencv-python",
-    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@b980f9b",
+    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@main",
 ]
 dynamic = ["version"]
 license.file = "LICENSE"

--- a/src/mx_bluesky/I24/serial/dcid.py
+++ b/src/mx_bluesky/I24/serial/dcid.py
@@ -377,9 +377,9 @@ def get_beamsize() -> tuple[float | None, float | None]:
     v_mode = caget("BL24I-OP-PSU-02:GROUP0:TARGETC")
     h_mode = caget("BL24I-OP-PSU-02:GROUP1:TARGETC")
     # Validate these and note an error otherwise
-    if not v_mode.startswith("VMFM") or not v_mode[4:] in focus_modes:
+    if not v_mode.startswith("VMFM") or v_mode[4:] not in focus_modes:
         logger.error("Unrecognised vertical beam mode %s", v_mode)
-    if not h_mode.startswith("HMFM") or not h_mode[4:] in focus_modes:
+    if not h_mode.startswith("HMFM") or h_mode[4:] not in focus_modes:
         logger.error("Unrecognised horizontal beam mode %s", h_mode)
     _, h, _ = focus_modes.get(h_mode[4:], (None, None, None))
     _, _, v = focus_modes.get(v_mode[4:], (None, None, None))

--- a/tests/I24/serial/fixed-target/test_ft_collect.py
+++ b/tests/I24/serial/fixed-target/test_ft_collect.py
@@ -59,7 +59,7 @@ def test_get_chip_prog_values():
         0,
         n_exposures=2,
     )
-    assert type(chip_dict) is dict
+    assert isinstance(chip_dict, dict)
     assert chip_dict["X_NUM_STEPS"][1] == 20 and chip_dict["X_NUM_BLOCKS"][1] == 8
     assert chip_dict["PUMP_REPEAT"][1] == 0
     assert chip_dict["N_EXPOSURES"][1] == 2


### PR DESCRIPTION
Closes #53 . 
Replace isort/flake8 in pre-commits with Ruff.

Also pin builds to 3.11 as p4p doesn't build in 3.12 (stop docs from failing)