### PR TITLE
I24 ssx test hotfixes

### DIFF
--- a/src/mx_bluesky/I24/serial/fixed_target/FT-gui-edm/DetStage.edl
+++ b/src/mx_bluesky/I24/serial/fixed_target/FT-gui-edm/DetStage.edl
@@ -3,8 +3,8 @@ beginScreenProperties
 major 4
 minor 0
 release 1
-x 3172
-y 731
+x 1943
+y 793
 w 450
 h 180
 font "arial-medium-r-18.0"
@@ -78,7 +78,7 @@ fgColour index 14
 bgColour index 4
 topShadowColour index 1
 botShadowColour index 8
-controlPv "ME-14E-MO-IOC-01:GP101"
+controlPv "ME14E-MO-IOC-01:GP101"
 font "arial-medium-r-18.0"
 numItems 2
 symbolTag {

--- a/src/mx_bluesky/I24/serial/log.py
+++ b/src/mx_bluesky/I24/serial/log.py
@@ -51,13 +51,18 @@ def _get_logging_file_path() -> Path:
     logging_path: Path
 
     if beamline:
-        # Until this https://github.com/DiamondLightSource/mx_bluesky/issues/45 is fixed
-        # Logs should go to the current visit directory or something
         logging_path = Path("/dls_sw/" + beamline + "/logs/serial/")
     else:
         logging_path = Path("./tmp/logs/")
 
-    Path(logging_path).mkdir(parents=True, exist_ok=True)
+    try:
+        Path(logging_path).mkdir(parents=True, exist_ok=True)
+    except OSError:
+        # Until https://github.com/DiamondLightSource/mx_bluesky/issues/45 is fixed
+        # Logs could also go to the current visit directory, but not always possible
+        # when testing
+        logging_path = Path("~/serial_logs/").expanduser().resolve()
+        Path(logging_path).mkdir(parents=True, exist_ok=True)
     return logging_path
 
 

--- a/src/mx_bluesky/I24/serial/log.py
+++ b/src/mx_bluesky/I24/serial/log.py
@@ -51,6 +51,8 @@ def _get_logging_file_path() -> Path:
     logging_path: Path
 
     if beamline:
+        # Until this https://github.com/DiamondLightSource/mx_bluesky/issues/45 is fixed
+        # Logs should go to the current visit directory or something
         logging_path = Path("/dls_sw/" + beamline + "/logs/serial/")
     else:
         logging_path = Path("./tmp/logs/")

--- a/src/mx_bluesky/I24/serial/setup_beamline/setup_detector.py
+++ b/src/mx_bluesky/I24/serial/setup_beamline/setup_detector.py
@@ -4,13 +4,12 @@ Utilities for defining the detector in use, and moving the stage.
 import argparse
 import logging
 import time
+from enum import IntEnum
 
 import bluesky.plan_stubs as bps
 from bluesky.run_engine import RunEngine
 from dodal.beamlines import i24
 from dodal.devices.i24.I24_detector_motion import DetectorMotion
-
-from enum import IntEnum
 
 from mx_bluesky.I24.serial import log
 from mx_bluesky.I24.serial.parameters.constants import SSXType

--- a/src/mx_bluesky/I24/serial/setup_beamline/setup_detector.py
+++ b/src/mx_bluesky/I24/serial/setup_beamline/setup_detector.py
@@ -10,6 +10,8 @@ from bluesky.run_engine import RunEngine
 from dodal.beamlines import i24
 from dodal.devices.i24.I24_detector_motion import DetectorMotion
 
+from enum import IntEnum
+
 from mx_bluesky.I24.serial import log
 from mx_bluesky.I24.serial.parameters.constants import SSXType
 from mx_bluesky.I24.serial.setup_beamline import pv
@@ -26,6 +28,11 @@ EXPT_TYPE_DETECTOR_PVS = {
     SSXType.FIXED: pv.me14e_gp101,
     SSXType.EXTRUDER: pv.ioc12_gp15,
 }
+
+
+class DetRequest(IntEnum):
+    eiger = 0
+    pilatus = 1
 
 
 def setup_logging():
@@ -64,11 +71,14 @@ def _move_detector_stage(detector_stage: DetectorMotion, target: float):
 def setup_detector_stage(detector_stage: DetectorMotion, expt_type: SSXType):
     # Grab the correct PV depending on experiment
     # Its value is set with MUX on edm screen
-    det_type = EXPT_TYPE_DETECTOR_PVS[expt_type]
-    requested_detector = caget(det_type)
+    det_type_pv = EXPT_TYPE_DETECTOR_PVS[expt_type]
+    det_type = caget(det_type_pv)
+    requested_detector = (
+        Eiger.name if int(det_type) == DetRequest.eiger else Pilatus.name
+    )
     logger.info(f"Requested detector: {requested_detector}.")
     det_y_target = (
-        Eiger.det_y_target if "eiger" in requested_detector else Pilatus.det_y_target
+        Eiger.det_y_target if requested_detector == "eiger" else Pilatus.det_y_target
     )
     yield from _move_detector_stage(detector_stage, det_y_target)
     logger.info("Detector setup done.")

--- a/tests/I24/serial/setup_beamline/test_setup_detector.py
+++ b/tests/I24/serial/setup_beamline/test_setup_detector.py
@@ -10,9 +10,9 @@ from ophyd.status import Status
 from mx_bluesky.I24.serial.parameters.constants import SSXType
 from mx_bluesky.I24.serial.setup_beamline import Eiger, Pilatus
 from mx_bluesky.I24.serial.setup_beamline.setup_detector import (
+    DetRequest,
     get_detector_type,
     setup_detector_stage,
-    DetRequest,
 )
 
 

--- a/tests/I24/serial/setup_beamline/test_setup_detector.py
+++ b/tests/I24/serial/setup_beamline/test_setup_detector.py
@@ -12,6 +12,7 @@ from mx_bluesky.I24.serial.setup_beamline import Eiger, Pilatus
 from mx_bluesky.I24.serial.setup_beamline.setup_detector import (
     get_detector_type,
     setup_detector_stage,
+    DetRequest,
 )
 
 
@@ -45,13 +46,13 @@ def test_get_detector_type_finds_pilatus(fake_caget):
 
 
 @patch("mx_bluesky.I24.serial.setup_beamline.setup_detector.caget")
-def test_setup_detector_stage_for_eiger(fake_caget, fake_detector_motion):
+def test_setup_detector_stage(fake_caget, fake_detector_motion):
     RE = RunEngine()
 
-    fake_caget.return_value = "eiger"
+    fake_caget.return_value = DetRequest.eiger.value
     RE(setup_detector_stage(fake_detector_motion, SSXType.FIXED))
     assert fake_detector_motion.y.user_readback.get() == Eiger.det_y_target
 
-    fake_caget.return_value = "pilatus"
+    fake_caget.return_value = DetRequest.pilatus.value
     RE(setup_detector_stage(fake_detector_motion, SSXType.EXTRUDER))
     assert fake_detector_motion.y.user_readback.get() == Pilatus.det_y_target


### PR DESCRIPTION
- [x] Wrong PV name
- [x] Set up and enum or something to look up what detector is requested. The choice on the edm will set the value to 0/1 instead of eiger/pilatus ( -> follow up to this: set up something similar for map_type and chip_type)
- [x] Temporary fix for log permission issue
- [x] OAV only uses crosshair from zoom 1.0, on I24 this is not updated beyond this line, so simply set that level for moveonclick

For Viewer/OAVParams issue see #44 
