### PR TITLE
Use new OAV from dodal for moveonclick

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "matplotlib",
     "requests",
     "opencv-python",
-    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@b01bf2f78c088b879b0f5a7d0bfc3691da505abb",
+    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@511ec01ea017a53a95b9c9ab85a0d922bfff3061",
 ]
 dynamic = ["version"]
 license.file = "LICENSE"

--- a/src/mx_bluesky/I24/serial/fixed_target/i24ssx_moveonclick.py
+++ b/src/mx_bluesky/I24/serial/fixed_target/i24ssx_moveonclick.py
@@ -4,7 +4,6 @@ Robin Owen 12 Jan 2021
 """
 import logging
 
-import bluesky.plan_stubs as bps
 import cv2 as cv
 from bluesky.run_engine import RunEngine
 from dodal.beamlines import i24
@@ -27,10 +26,6 @@ def _get_beam_centre(oav: OAV):
     Args:
         oav (OAV): the OAV device.
     """
-    # Set to 1.0, as this is the only value that is updated in display config
-    # on the beamline (all other beam positions will be invalid)
-    yield from bps.abs_set(oav.zoom_controller, "1.0", wait=True)
-
     return oav.parameters.beam_centre_i, oav.parameters.beam_centre_j
 
 


### PR DESCRIPTION
Use the new OAV parameters definition, which has been changed so that the ones inherent to the OAV are now decoupled from the context. 

See also [Dodal#224](https://github.com/DiamondLightSource/dodal/pull/239) 