### PR TITLE
Add checker pattern to pump probe for I24 serial

### DIFF
--- a/src/mx_bluesky/I24/serial/fixed_target/FT-gui-edm/pumpprobe-py3v1.edl
+++ b/src/mx_bluesky/I24/serial/fixed_target/FT-gui-edm/pumpprobe-py3v1.edl
@@ -3,8 +3,8 @@ beginScreenProperties
 major 4
 minor 0
 release 1
-x 1570
-y 705
+x 3174
+y 381
 w 900
 h 700
 font "arial-medium-r-18.0"
@@ -1557,5 +1557,56 @@ value {
   " laser delay+dwell > total X-ray exposure"
 }
 autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 6
+y 275
+w 191
+h 27
+font "arial-bold-r-24.0"
+fgColor index 12
+bgColor index 0
+useDisplayBg
+value {
+  "Checker Pattern"
+}
+autoSize
+endObjectProperties
+
+# (Menu Mux)
+object menuMuxClass
+beginObjectProperties
+major 4
+minor 1
+release 0
+x 207
+y 276
+w 82
+h 24
+fgColor index 14
+bgColor index 3
+topShadowColor index 1
+botShadowColor index 8
+controlPv "ME14E-MO-IOC-01:GP111"
+font "arial-medium-r-18.0"
+numItems 2
+symbolTag {
+  0 "False"
+  1 "True"
+}
+symbol0 {
+  0 "NN"
+  1 "ML"
+}
+value0 {
+  0 "none"
+  1 "True"
+}
 endObjectProperties
 

--- a/src/mx_bluesky/I24/serial/fixed_target/i24ssx_Chip_Collect_py3v1.py
+++ b/src/mx_bluesky/I24/serial/fixed_target/i24ssx_Chip_Collect_py3v1.py
@@ -184,6 +184,10 @@ def load_motion_program_data(motion_program_dict, map_type, pump_repeat):
         # Pump setting chosen
         prefix = 14
         logger.info("Setting program prefix to %s" % prefix)
+        caput(pv.me14e_pmac_str, "P1439=0")
+        if bool(caget(pv.me14e_gp111)) is True:
+            logger.info("Checker pattern setting enabled.")
+            caput(pv.me14e_pmac_str, "P1439=1")
     else:
         logger.warning("Unknown Pump repeat, pump_repeat = %s" % pump_repeat)
         return

--- a/src/mx_bluesky/I24/serial/fixed_target/i24ssx_Chip_Manager_py3v1.py
+++ b/src/mx_bluesky/I24/serial/fixed_target/i24ssx_Chip_Manager_py3v1.py
@@ -128,6 +128,8 @@ def write_parameter_file(param_path: Path | str = PARAM_FILE_PATH_FT):
     chip_type = caget(pv.me14e_gp1)
     det_type = get_detector_type()
 
+    checkerpattern = bool(caget(pv.me14e_gp111))
+
     # If file name ends in a digit this causes processing/pilatus pain.
     # Append an underscore
     if det_type == "pilatus":
@@ -158,19 +160,21 @@ def write_parameter_file(param_path: Path | str = PARAM_FILE_PATH_FT):
         f.write("exptime \t%s\n" % exptime)
         f.write("dcdetdist \t%s\n" % dcdetdist)
         f.write("det_type \t%s\n" % str(det_type))
+        f.write("checkerpattern \t%s\n" % str(checkerpattern))
 
     logger.info("Information written to file")
-    logger.info("visit: %s" % visit)
-    logger.info("filename: %s" % chip_name)
-    logger.info("protein_name: %s" % protein_name)
-    logger.info("n_exposures: %s" % n_exposures)
-    logger.info("chip_type: %s" % chip_type)
-    logger.info("map_type: %s" % map_type)
-    logger.info("pump_repeat: %s" % pump_repeat)
-    logger.info("pumpexptime: %s" % pumpexptime)
-    logger.info("pumpdelay: %s" % pumpdelay)
-    logger.info("prepumpexptime: %s" % prepumpexptime)
-    logger.info("detector type: %s" % str(det_type))
+    logger.info(f"visit: {visit}")
+    logger.info(f"filename: {chip_name}")
+    logger.info(f"protein_name: {protein_name}")
+    logger.info(f"n_exposures: {n_exposures}")
+    logger.info(f"chip_type: {chip_type}")
+    logger.info(f"map_type: {map_type}")
+    logger.info(f"pump_repeat: {pump_repeat}")
+    logger.info(f"pumpexptime: {pumpexptime}")
+    logger.info(f"pumpdelay: {pumpdelay}")
+    logger.info(f"prepumpexptime: {prepumpexptime}")
+    logger.info(f"detector type: {str(det_type)}")
+    logger.info(f"checker pattern: {checkerpattern}")
     if map_type == MappingType.Full:
         # This step creates some header files (.addr, .spec), containing the parameters,
         # that are only needed when full mapping is in use.


### PR DESCRIPTION
Closes #65 

Adds new setting to to the pump probe options, which sends a command to the pmac to only have the pump_repeat applied every other city block.