### PR TITLE
Get correct beam position directly from OAV device

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "matplotlib",
     "requests",
     "opencv-python",
-    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@b1bca02c7e87b11f077a2363e200218fd3b1ff00",
+    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@a43c6be33f5c9361981ca8202109c86c57d00afc",
 ]
 dynamic = ["version"]
 license.file = "LICENSE"

--- a/src/mx_bluesky/I24/serial/fixed_target/i24ssx_moveonclick.py
+++ b/src/mx_bluesky/I24/serial/fixed_target/i24ssx_moveonclick.py
@@ -24,12 +24,7 @@ def _get_beam_centre(oav: OAV):
     Args:
         oav (OAV): the OAV device.
     """
-    beamX, beamY = oav.parameters.beam_centre_i, oav.parameters.beam_centre_j
-    # Re-scale beam position to an image of 1024x768 to get the correct values
-    # See https://github.com/DiamondLightSource/dodal/issues/249
-    beamX *= 1292 / 1024
-    beamY *= 964 / 768
-    return int(beamX), int(beamY)
+    return oav.parameters.beam_centre_i, oav.parameters.beam_centre_j
 
 
 # TODO In the future, this should be done automatically in the OAV device


### PR DESCRIPTION
Needs [Dodal#258](https://github.com/DiamondLightSource/dodal/pull/258)

Logic for rescaling the beam position has been moved to the OAV device in dodal.

To test:
- Run tests and check they still pass