### PR TITLE
Update ruff linter settings in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,11 +70,11 @@ ignore_missing_imports = true # Ignore missing stubs in imported modules
 [tool.ruff]
 src = ["src", "tests"]
 line-length = 88
-extend-ignore = [
+lint.extend-ignore = [
     "E501", # Line too long
     "F811", # support typing.overload decorator
 ]
-select = [
+lint.select = [
     "C4",   # flake8-comprehensions - https://beta.ruff.rs/docs/rules/#flake8-comprehensions-c4
     "E",    # pycodestyle errors - https://beta.ruff.rs/docs/rules/#error-e
     "F",    # pyflakes rules - https://beta.ruff.rs/docs/rules/#pyflakes-f


### PR DESCRIPTION
Ruff options updated in pyproject as old ones deprecated:
  - 'extend-ignore' -> 'lint.extend-ignore'
  - 'select' -> 'lint.select'