### PR TITLE
Tidy up stages initialisation

### DIFF
--- a/src/mx_bluesky/I24/serial/fixed_target/i24ssx_Chip_Manager_py3v1.py
+++ b/src/mx_bluesky/I24/serial/fixed_target/i24ssx_Chip_Manager_py3v1.py
@@ -49,7 +49,6 @@ def setup_logging():
 @log.log_on_entry
 def initialise_stages(
     pmac: PMAC = inject("pmac"),
-    detector_stage: DetectorMotion = inject("detector_motion"),
 ) -> MsgGenerator:
     """Initialise the portable stages PVs, usually used only once right after setting \
         up the stages either after use at different facility.
@@ -57,7 +56,7 @@ def initialise_stages(
     setup_logging()
     group = "initialise_stages"
     # commented out filter lines 230719 as this stage not connected
-    logger.info("Setting VMAX VELO ACCL HHL LLM pvs for stages")
+    logger.info("Setting VELO ACCL HHL LLM pvs for stages")
 
     yield from bps.abs_set(pmac.x.velocity, 20, group=group)
     yield from bps.abs_set(pmac.y.velocity, 20, group=group)
@@ -88,13 +87,6 @@ def initialise_stages(
     yield from bps.abs_set(pmac.enc_reset, EncReset.ENC7, group=group)
     yield from bps.abs_set(pmac.enc_reset, EncReset.ENC8, group=group)
 
-    # TODO Split this out.
-    # Detector bit is unrelated, just here for convenience sake
-    # See https://github.com/DiamondLightSource/mx_bluesky/issues/51
-    # Define detector in use
-    logger.debug("Define detector in use.")
-    det_type = yield from get_detector_type(detector_stage)
-
     caput(pv.pilat_cbftemplate, 0)
 
     sleep(0.1)
@@ -106,9 +98,12 @@ def initialise_stages(
         sys.stdout.flush()
 
     caput(pv.me14e_gp100, "press set params to read visit")
-    caput(pv.me14e_gp101, det_type.name)
 
-    logger.info("Initialisation Complete")
+    logger.info("Initialisation of the stages complete")
+    logger.info(
+        """To define detector in use and set the PV accordingly, use the MUX choice \
+            on the `Detector` screen."""
+    )
     yield from bps.wait(group=group)
 
 

--- a/src/mx_bluesky/I24/serial/fixed_target/i24ssx_Chip_Manager_py3v1.py
+++ b/src/mx_bluesky/I24/serial/fixed_target/i24ssx_Chip_Manager_py3v1.py
@@ -59,12 +59,6 @@ def initialise_stages(
     # commented out filter lines 230719 as this stage not connected
     logger.info("Setting VMAX VELO ACCL HHL LLM pvs for stages")
 
-    # NOTE .VMAX is read only in ohpyd_async motor, should be removed in the future
-    # See https://github.com/DiamondLightSource/mx_bluesky/issues/109
-    caput(pv.me14e_stage_x + ".VMAX", 20)
-    caput(pv.me14e_stage_y + ".VMAX", 20)
-    caput(pv.me14e_stage_z + ".VMAX", 20)
-    # caput(pv.me14e_filter  + '.VMAX', 20)
     yield from bps.abs_set(pmac.x.velocity, 20, group=group)
     yield from bps.abs_set(pmac.y.velocity, 20, group=group)
     yield from bps.abs_set(pmac.z.velocity, 20, group=group)

--- a/src/mx_bluesky/I24/serial/fixed_target/i24ssx_Chip_Manager_py3v1.py
+++ b/src/mx_bluesky/I24/serial/fixed_target/i24ssx_Chip_Manager_py3v1.py
@@ -55,25 +55,20 @@ def initialise_stages(
     """
     setup_logging()
     group = "initialise_stages"
-    # commented out filter lines 230719 as this stage not connected
-    logger.info("Setting VELO ACCL HHL LLM pvs for stages")
+    logger.info("Setting velocity, acceleration and limits for stages")
 
     yield from bps.abs_set(pmac.x.velocity, 20, group=group)
     yield from bps.abs_set(pmac.y.velocity, 20, group=group)
     yield from bps.abs_set(pmac.z.velocity, 20, group=group)
-    # caput(pv.me14e_filter  + '.VELO', 20)
     yield from bps.abs_set(pmac.x.acceleration_time, 0.01, group=group)
     yield from bps.abs_set(pmac.y.acceleration_time, 0.01, group=group)
     yield from bps.abs_set(pmac.z.acceleration_time, 0.01, group=group)
-    # caput(pv.me14e_filter  + '.ACCL', 0.01)
     yield from bps.abs_set(pmac.x.high_limit_travel, 30, group=group)
     yield from bps.abs_set(pmac.x.low_limit_travel, -29, group=group)
     yield from bps.abs_set(pmac.y.high_limit_travel, 30, group=group)
     yield from bps.abs_set(pmac.y.low_limit_travel, -30, group=group)
     yield from bps.abs_set(pmac.z.high_limit_travel, 5.1, group=group)
     yield from bps.abs_set(pmac.z.low_limit_travel, -4.1, group=group)
-    # caput(pv.me14e_filter  + '.HLM', 45.0)
-    # caput(pv.me14e_filter  + '.LLM', -45.0)
     caput(pv.me14e_gp1, 1)
     caput(pv.me14e_gp2, 0)
     caput(pv.me14e_gp3, 1)
@@ -100,10 +95,6 @@ def initialise_stages(
     caput(pv.me14e_gp100, "press set params to read visit")
 
     logger.info("Initialisation of the stages complete")
-    logger.info(
-        """To define detector in use and set the PV accordingly, use the MUX choice \
-            on the `Detector` screen."""
-    )
     yield from bps.wait(group=group)
 
 

--- a/tests/I24/serial/fixed_target/test_chip_manager.py
+++ b/tests/I24/serial/fixed_target/test_chip_manager.py
@@ -2,9 +2,7 @@ import json
 from typing import List
 from unittest.mock import ANY, MagicMock, call, mock_open, patch
 
-import bluesky.plan_stubs as bps
 import pytest
-from dodal.devices.i24.I24_detector_motion import DetectorMotion
 from dodal.devices.i24.pmac import PMAC
 from ophyd_async.core import get_mock_put
 
@@ -21,7 +19,6 @@ from mx_bluesky.I24.serial.fixed_target.i24ssx_Chip_Manager_py3v1 import (
     scrape_mtr_fiducials,
     set_pmac_strings_for_cs,
 )
-from mx_bluesky.I24.serial.setup_beamline import Eiger
 
 mtr_dir_str = """#Some words
 mtr1_dir=1
@@ -46,17 +43,9 @@ async def test_initialise(
     fake_sys: MagicMock,
     fake_log: MagicMock,
     pmac: PMAC,
-    detector_stage: DetectorMotion,
     RE,
 ):
-    def fake_generator(value):
-        yield from bps.null()
-        return value
-
-    fake_det.side_effect = [fake_generator(Eiger())]
-    RE(initialise_stages(pmac, detector_stage))
-
-    fake_caput.assert_called_with(ANY, "eiger")  # last call should be detector
+    RE(initialise_stages(pmac))
 
     assert await pmac.x.velocity.get_value() == 20
     assert await pmac.y.acceleration_time.get_value() == 0.01


### PR DESCRIPTION
Closes #109 
Closes #51 

A bit of tidying up in `initialise_stages` i.e. the plan run once in awhile when the stages have been off and rebooted.

- [x] Remove setting .VMAX as it's now 20 by default in controls
- [x] Remove setting the detector, as the `ME14E-MO-IOC-01:GP101` PV can now be re-initialised using the MUX choice in the `Detector` edm. Add a message at the end reminding the user to do that. 
