### PR TITLE
Fix linting 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
         name: Run ruff
         stages: [commit]
         language: system
-        entry: ruff
+        entry: ruff check --force-exclude
         types: [python]
 
   # Type checking


### PR DESCRIPTION
Fixes error in CI

```error: `ruff <path>` has been removed. Use `ruff check <path>` instead.```

`ruff path` has been deprecated, need to update pre-commits 